### PR TITLE
Updated links, provided overviews, fixed grammar.

### DIFF
--- a/site/_includes/guidenav.html
+++ b/site/_includes/guidenav.html
@@ -1,9 +1,11 @@
 <div class="sidebar">
   <h2><ul>
+    <li><a class="{% if page.url contains '/guide/whatis' %}active{% endif %}" href="{{site.baseurl}}/guide/whatis">What is Switchboard</a></li>
     <li><a class="{% if page.url contains '/guide/install' %}active{% endif %}" href="{{site.baseurl}}/guide/install">Installation</a></li>
     <li><a class="{% if page.url contains '/guide/client' %}active{% endif %}" href="{{site.baseurl}}/guide/client">Client Interface</a></li>
     <li><a class="{% if page.url contains '/guide/examples' %}active{% endif %}" href="{{site.baseurl}}/guide/examples">Examples</a></li>
     <li><a class="{% if page.url contains '/guide/contributing' %}active{% endif %}" href="{{site.baseurl}}/guide/contributing">Contributing</a></li>
+    <li><a target="_blank" href="{{site.baseurl}}/doc">API Docs</a></li>
     <li><a class="{% if page.url contains '/guide/faq' %}active{% endif %}" href="{{site.baseurl}}/guide/faq">FAQ</a></li>
   </ul></h2>
 </div>

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -6,7 +6,6 @@
   <div class="menu">
     <ul>
       <li><a class="{% if page.url contains '/guide' %}active{% endif %}" href="{{site.baseurl}}/guide/install">Getting Started</a></li>
-      <li><a href="{{site.baseurl}}/doc" target="_blank">Docs</a></li>
       <li><a class="{% if page.url contains '/about' %}active{% endif %}" href="{{site.baseurl}}/about">About</a></li>
       <li class="github"><a href="https://github.com/thusfresh/switchboard">Github</a></li>
     </ul>

--- a/site/guide/examples.md
+++ b/site/guide/examples.md
@@ -4,27 +4,27 @@ layout: guide
 
 ## Examples
 
-### Overview
-
-Switchboard [and JMAP] are young, so there are only two client
-implementations:
-
 {::comment}
 TODO - add python client
 {:/comment}
 
-- A javascript client located inkkkkk
-- A ruby client
+Switchboard allows developers to develop a wide variety of clients.
+This section will point you towards existing example clients, as well
+as walk you through how to write your own client in Ruby.
 
-Switchboard allows developers to develop a wide variety of clients. The 
-following sourcefile contains comments mapping out common components of a
-Switchboard client, and is a great reference for understanding how the
-protocol works.
+### Javascript Client
+
+Since the Switchboard protocol uses JSON over WebSockets, it's only fitting for
+there to be a JavaScript client. Switchboard comes with one.
 
 To try the client out, start the Switchboard application and point
-your browser at http://127.0.0.1:8080/jsclient - it should display 
-a page with some getting started commands. Open your browser's 
-javascript console and try them out.
+your browser at
+[http://127.0.0.1:8080/jsclient](http://127.0.0.1:8080/jsclient) - it
+should display a page with some getting started commands. Open your
+browser's javascript console and try them out.  The following
+sourcefile contains comments mapping out common components of a
+Switchboard client, and is a great reference for understanding how the
+protocol works.
 
 {::comment}
 ### Push Notifications
@@ -32,9 +32,9 @@ javascript console and try them out.
 
 ### Ruby Sample App Tutorial - Email Dropbox Uploader
 
-### Email 
-
-Follow this example tutorial to build your first `switchboard` client in Ruby. This simple example, to be run in the command line, syncs attachments from a user's emails to his or her Dropbox.
+Follow this example tutorial to build your first `switchboard` client
+in Ruby. This simple example, to be run in the command line, syncs
+attachments from a user's emails to his or her Dropbox.
 
 #### Setup
 

--- a/site/guide/whatis.md
+++ b/site/guide/whatis.md
@@ -1,0 +1,52 @@
+---
+layout: guide
+---
+
+## What is Switchboard?
+
+Switchboard provides high-level tools for managing IMAP clients across
+multiple email accounts and providers, and an API allowing workers to
+process emails as they arrive. It handles the boilerplate of IMAP
+connection management and new email monitoring so that you can focus
+on innovating around email.
+
+### Features
+
+<ul class="bulletPoints1">
+<li>
+  Totally open source &mdash; developers can extend Switchboard or use
+  the API to create workers specific to their product.
+</li>
+<li>
+  Switchboard handles the boilerplate, leaving the logic to you
+  &mdash; Swtichboard frees you from the plumbing of server-side email
+  monitoring and fetching, allowing you to focus on your products
+  and services.
+</li>
+<li>
+  In the cloud &mdash; having processes running in the cloud,
+  Switchboard can help you avoid mobile OS backgrounding restrictions
+  and heavy battery consumption, freeing up local memory and leaving
+  you in control of your service.
+</li>
+</ul>
+
+### First Steps
+
+You are at the beginning of the Switchboard User Guide. This guide can
+take you from installation, to setting up a client or worker.
+
+To get Switchboard up and running, take a look at the
+[install]({{site.baseurl}}/guide/install) pages.
+
+To see an example of how Switchboard can be used, see the
+[Examples]({{site.baseurl}}/guide/examples) pages with examples and
+walkthroughs on:
+
+<ul class="bulletPoints1">
+  <li>Sending email push notifications</li>
+  <li>Storing email image attachments on Dropbox folder</li>
+</ul>
+
+To see documenation of the Switchboard application's modules and
+functions, see the [API Docs]({{site.baseurl}}/doc).


### PR DESCRIPTION
Moved API Docs under the User Guide, added "What is Switchboard" guide, and fixed up the "Examples" guide overview.
