### PR TITLE
Added .travis.yml for R16 using erlang.mk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: erlang
+otp_release:
+  - R16B03-1
+  - R16B02
+  - R16B01
+install: make deps
+script: make rel

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Switchboard
 
+[![Build Status](https://travis-ci.org/thusfresh/switchboard.svg?branch=master)](https://travis-ci.org/thusfresh/switchboard)
+
 Switchboard provides high-level tools for managing IMAP clients across
 multiple email accounts and providers, and an API allowing workers to
 process emails as they arrive.


### PR DESCRIPTION
References #17.

At the moment, this is only building and packaging the release. Once #22 is done, I'll add a step to run the tests.
