### PR TITLE
Fixes handling of no Host in an email address description (See #51)

### DIFF
--- a/src/imap.erl
+++ b/src/imap.erl
@@ -77,6 +77,7 @@
 -ifdef(TEST).
 %% When testing, export additional functions
 -export([clean_addresses/1,
+         build_address/2,
          clean_body/1,
          cmd_to_list/1,
          seqset_to_list/1,
@@ -876,14 +877,23 @@ clean_addresses(Addresses) ->
     [address()].
 clean_addresses([], Acc) ->
     lists:reverse(Acc);
-clean_addresses([[RawName, _, {string, MailBox}, {string, Host}] | Rest], Acc) ->
-    Address = [{email, <<MailBox/binary, $@, Host/binary>>}],
+clean_addresses([[RawName, _, {string, MailBox}, Host] | Rest], Acc) ->
+    Address = build_address(MailBox, Host),
     clean_addresses(Rest,
                     [{address, case RawName of
                                    nil -> [{name, <<"">>} | Address];
                                    {string, Name} -> [{name, Name} | Address]
                                end} |
                      Acc]).
+
+%% @private
+%% Concatenates a Mailbox and a Host (if one provided)
+build_address(MailBox, Host) ->
+  Domain = case Host of
+             {string, Str} -> Str;
+             _ -> <<"">>
+           end,
+  [{email, <<MailBox/binary, $@, Domain/binary>>}].
 
 %% @private
 %% If the address is wrapped by `<...>', strip the angle brackets

--- a/src/test/eunit/imap_tests.erl
+++ b/src/test/eunit/imap_tests.erl
@@ -86,6 +86,7 @@ start_dispatch() ->
 clean_suite_test_() ->
     [clean_body_assertions(),
      clean_address_assertions(),
+     build_address_assertions(),
      clean_assertions(),
      get_parts_by_type_assertions()].
 
@@ -107,6 +108,12 @@ clean_address_assertions() ->
     [?_assertEqual([{address, [{name, <<"John Doe">>}, {email, <<"john@gmail.com">>}]},
                     {address, [{name, <<"Jane Doe">>}, {email, <<"jane@gmail.com">>}]}],
                    imap:clean_addresses(?ADDRESSES))].
+
+build_address_assertions() ->
+    [?_assertEqual([{email, <<"john@gmail.com">>}],
+                   imap:build_address(<<"john">>, {string, <<"gmail.com">>})),
+     ?_assertEqual([{email, <<"john@">>}],
+                   imap:build_address(<<"john">>, nil))].
 
 clean_assertions() ->
     [?_assertMatch({fetch, [{uid, 37},


### PR DESCRIPTION
Fixes handling of no Host in an email address description, originally in #51, as per the discussion on https://github.com/jmapio/jmap/issues/13.

This issue caused some messages to crash the account process and thus publish the `message` event.