### PR TITLE
Support IDLE-ing on arbitrary mailboxes

### DIFF
--- a/src/switchboard_idler.erl
+++ b/src/switchboard_idler.erl
@@ -72,7 +72,7 @@ init({ConnSpec, Auth, Mailbox}) ->
                 {imap, start_link,
                  [ConnSpec,
                   [{cmds, [{cmd, {call, {login, Auth}}},
-                           {cmd, {call, {select, <<"INBOX">>}}},
+                           {cmd, {call, {select, Mailbox}}},
                            {cmd, {cast, idle}, [{dispatch, DispatchFun}]}]},
                    {post_init_callback,
                     switchboard:register_callback(Account, {idler, Mailbox})}]]},

--- a/src/switchboard_operator.erl
+++ b/src/switchboard_operator.erl
@@ -197,6 +197,7 @@ update_uid_internal(#state{account=Account,
                     Uid) when Uid > LastUid ->
     {ok, {_, Emails}} = switchboard:with_imap(Account,
                             fun(IMAP) ->
+                                {ok, _} = imap:call(IMAP, {select, Mailbox}),
                                 imap:call(IMAP, {uid, {fetch, {LastUid + 1, Uid}, <<"ALL">>}})
                             end),
     lists:foreach(


### PR DESCRIPTION
Also, the switchboard_operator could get confused since it didn't
explicitly select a mailbox in `update_uid_internal/2`.