### PR TITLE
Make `inreplyto` jsx-able

### DIFF
--- a/src/imap.erl
+++ b/src/imap.erl
@@ -875,7 +875,7 @@ clean_addresses(nil) ->
 clean_addresses({string, <<"">>}) ->
     [];
 clean_addresses({string, Address}) ->
-    [address, {email, strip_address(Address)}];
+    [{address, [{email, strip_address(Address)}]}];
 clean_addresses(Addresses) ->
     clean_addresses(Addresses, []).
 


### PR DESCRIPTION
Emails with a non-empty `inreplyto` would not be json-compatible since
they would have an element of their envelope like:

```
{inreplyto, [address, {email, <<"message-id">>}]}
```